### PR TITLE
Add lazy loading for user avatars

### DIFF
--- a/public/app1.html
+++ b/public/app1.html
@@ -15,6 +15,7 @@
 
     <!-- Custom fonts for this template-->
     <link href="vendor/fontawesome-free/css/all.min.css" rel="stylesheet" type="text/css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
     <link
         href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i"
         rel="stylesheet">
@@ -197,7 +198,7 @@
                                 data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 <span id="user-name" class="mr-2 d-none d-lg-inline text-gray-600 small">Usuario Admin</span>
                                 <img id="user-photo" class="img-profile rounded-circle"
-                                    src="https://source.unsplash.com/QAB-WJcbgJk/60x60">
+                                    src="https://source.unsplash.com/QAB-WJcbgJk/60x60" loading="lazy">
                             </a>
                             <!-- Dropdown - User Information -->
                             <div class="dropdown-menu dropdown-menu-right shadow animated--grow-in"

--- a/public/app2.html
+++ b/public/app2.html
@@ -208,7 +208,7 @@
                                 data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 <span id="user-name" class="mr-2 d-none d-lg-inline text-gray-600 small">Usuario Admin</span>
                                 <img id="user-photo" class="img-profile rounded-circle"
-                                    src="https://source.unsplash.com/QAB-WJcbgJk/60x60">
+                                    src="https://source.unsplash.com/QAB-WJcbgJk/60x60" loading="lazy">
                             </a>
                         </li>
                     </ul>

--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,7 @@
 
     <!-- Custom fonts for this template-->
     <link href="vendor/fontawesome-free/css/all.min.css" rel="stylesheet" type="text/css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
     <link
         href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i"
         rel="stylesheet">
@@ -98,7 +99,7 @@
                             <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button"
                                 data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 <span id="user-name" class="mr-2 d-none d-lg-inline text-gray-600 small"></span>
-                                <img id="user-photo" class="img-profile rounded-circle" src="img/undraw_profile.svg">
+                                <img id="user-photo" class="img-profile rounded-circle" src="img/undraw_profile.svg" loading="lazy">
                             </a>
                             <div class="dropdown-menu dropdown-menu-right shadow animated--grow-in"
                                 aria-labelledby="userDropdown">


### PR DESCRIPTION
## Summary
- optimize font loading by preconnecting to Google Fonts
- defer user avatar images using `loading="lazy"`

## Testing
- `npm test` *(fails: missing `package.json`)*
- `npm install puppeteer` *(fails: blocked by network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686dcc13dc84832f847d5dd68f735f79