### PR TITLE
Add loading spinner overlay for data tables

### DIFF
--- a/public/app1.html
+++ b/public/app1.html
@@ -91,6 +91,9 @@
             font-weight: 700;
             color: #4e73df;
         }
+        #loading-spinner {
+            z-index: 1051;
+        }
     </style>
 </head>
 
@@ -301,6 +304,11 @@
     <!-- Contenedores de la aplicación para Modales y Toasts -->
     <div id="modal-container"></div>
     <div id="toast-container"></div>
+    <div id="loading-spinner" class="hidden fixed inset-0 flex items-center justify-center bg-gray-800 bg-opacity-50">
+        <div class="spinner-border text-light" role="status" style="width: 3rem; height: 3rem;">
+            <span class="sr-only">Cargando...</span>
+        </div>
+    </div>
 
 
     <!-- Bootstrap core JavaScript-->

--- a/public/js/app1-logic.js
+++ b/public/js/app1-logic.js
@@ -272,8 +272,11 @@ function switchView(viewName) {
         tableContainer.classList.remove('hidden');
         headerActions.classList.remove('hidden');
         addButtonText.textContent = `Agregar ${config.title.slice(0, -1)}`;
+        const spinner = document.getElementById('loading-spinner');
+        if (spinner) spinner.classList.remove('hidden');
         currentData = [...db[config.dataKey]];
         renderTable(currentData, config);
+        if (spinner) spinner.classList.add('hidden');
     }
     searchInput.value = '';
 }


### PR DESCRIPTION
## Summary
- add overlay spinner container in `app1.html`
- show/hide spinner when switching to data views in `app1-logic.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686dd07ad5f8832f98db3ffe7f7ef002