### PR TITLE
Add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
 
     <!-- Custom styles for this template-->
     <link href="css/sb-admin-2.min.css" rel="stylesheet">
+    <link href="css/theme.css" rel="stylesheet">
 
 </head>
 
@@ -97,7 +98,7 @@
 
     <!-- Custom scripts for all pages-->
     <script src="js/sb-admin-2.min.js"></script>
+    <script src="js/theme-toggle.js"></script>
 
 </body>
-
 </html>

--- a/public/app1.html
+++ b/public/app1.html
@@ -23,6 +23,7 @@
     <!-- Custom styles for this template-->
     <link href="css/sb-admin-2.min.css" rel="stylesheet">
     <link href="css/custom-transitions.css" rel="stylesheet">
+    <link href="css/theme.css" rel="stylesheet">
 
 
     <!-- Scripts y Estilos de la Aplicación Original (no relacionados con la plantilla) -->
@@ -195,6 +196,11 @@
                     </button>
                     <!-- Topbar Navbar -->
                     <ul class="navbar-nav ml-auto">
+                        <li class="nav-item">
+                            <button id="theme-toggle" class="nav-link btn btn-link">
+                                <i class="fas fa-adjust"></i>
+                            </button>
+                        </li>
                         <div class="topbar-divider d-none d-sm-block"></div>
                         <!-- Nav Item - User Information -->
                         <li class="nav-item dropdown no-arrow">
@@ -320,6 +326,7 @@
 
     <!-- SB Admin scripts -->
     <script src="js/sb-admin-2.min.js"></script>
+    <script src="js/theme-toggle.js"></script>
 
     <!-- Scripts de la Aplicación -->
     <script src="js/app1-logic.js" type="module"></script>

--- a/public/app2.html
+++ b/public/app2.html
@@ -16,6 +16,7 @@
     <!-- Estilos personalizados para esta plantilla (ruta local) -->
     <link href="css/sb-admin-2.min.css" rel="stylesheet">
     <link href="css/custom-transitions.css" rel="stylesheet">
+    <link href="css/theme.css" rel="stylesheet">
 
     <!-- Scripts y Estilos de la Aplicación Sinóptico -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -202,6 +203,11 @@
                     </button>
                     <!-- Topbar Navbar -->
                     <ul class="navbar-nav ml-auto">
+                        <li class="nav-item">
+                            <button id="theme-toggle" class="nav-link btn btn-link">
+                                <i class="fas fa-adjust"></i>
+                            </button>
+                        </li>
                         <div class="topbar-divider d-none d-sm-block"></div>
                         <!-- Nav Item - User Information -->
                         <li class="nav-item dropdown no-arrow">
@@ -341,6 +347,7 @@
 
     <!-- SB Admin scripts -->
     <script src="js/sb-admin-2.min.js"></script>
+    <script src="js/theme-toggle.js"></script>
 
     <!-- Firebase SDKs -->
     <script src="/__/firebase/11.10.0/firebase-app-compat.js"></script>

--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -1,0 +1,21 @@
+:root {
+  --bg-color: #f8f9fc;
+  --text-color: #5a5c69;
+  --sidebar-bg: #4e73df;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+
+.sidebar {
+  background-color: var(--sidebar-bg) !important;
+  background-image: none !important;
+}
+
+.dark-mode {
+  --bg-color: #1f2937;
+  --text-color: #f8f9fa;
+  --sidebar-bg: #343a40;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -21,6 +21,7 @@
     <!-- Custom styles for this template-->
     <link href="css/sb-admin-2.min.css" rel="stylesheet">
     <link href="css/custom-transitions.css" rel="stylesheet">
+    <link href="css/theme.css" rel="stylesheet">
 
 </head>
 
@@ -96,6 +97,11 @@
                 <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
                     <!-- ... (El resto de tu Topbar) ... -->
                     <ul class="navbar-nav ml-auto">
+                        <li class="nav-item">
+                            <button id="theme-toggle" class="nav-link btn btn-link">
+                                <i class="fas fa-adjust"></i>
+                            </button>
+                        </li>
                         <li class="nav-item dropdown no-arrow">
                             <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button"
                                 data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -166,6 +172,7 @@
 
     <!-- Custom scripts for all pages-->
     <script src="js/sb-admin-2.min.js"></script>
+    <script src="js/theme-toggle.js"></script>
 
     <!-- Firebase SDKs -->
     <script defer src="/__/firebase/11.10.0/firebase-app-compat.js"></script>

--- a/public/js/theme-toggle.js
+++ b/public/js/theme-toggle.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('theme-toggle');
+  if (!btn) return;
+
+  const applyStored = () => {
+    const stored = localStorage.getItem('theme');
+    if (stored === 'dark') {
+      document.body.classList.add('dark-mode');
+    }
+  };
+
+  applyStored();
+
+  btn.addEventListener('click', () => {
+    document.body.classList.toggle('dark-mode');
+    const mode = document.body.classList.contains('dark-mode') ? 'dark' : 'light';
+    localStorage.setItem('theme', mode);
+  });
+});

--- a/public/login.html
+++ b/public/login.html
@@ -19,6 +19,7 @@
 
     <!-- Custom styles for this template-->
     <link href="css/sb-admin-2.min.css" rel="stylesheet">
+    <link href="css/theme.css" rel="stylesheet">
 
 </head>
 
@@ -97,6 +98,7 @@
 
     <!-- Custom scripts for all pages-->
     <script src="js/sb-admin-2.min.js"></script>
+    <script src="js/theme-toggle.js"></script>
 
     <!-- Firebase SDKs -->
     <script defer src="/__/firebase/11.10.0/firebase-app-compat.js"></script>
@@ -109,5 +111,4 @@
     <script defer src="js/firebase-auth.js"></script>
 
 </body>
-
 </html>


### PR DESCRIPTION
## Summary
- define CSS variables and dark mode values
- add theme toggler button in the topbar
- remember user's preference in `localStorage`
- include styles and script on all pages

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686dd2e825ac832fb1155e947125a8f5