### PR TITLE
Improve toast accessibility

### DIFF
--- a/public/app1.html
+++ b/public/app1.html
@@ -309,7 +309,7 @@
 
     <!-- Contenedores de la aplicación para Modales y Toasts -->
     <div id="modal-container"></div>
-    <div id="toast-container"></div>
+    <div id="toast-container" role="region" aria-live="polite"></div>
     <div id="loading-spinner" class="hidden fixed inset-0 flex items-center justify-center bg-gray-800 bg-opacity-50">
         <div class="spinner-border text-light" role="status" style="width: 3rem; height: 3rem;">
             <span class="sr-only">Cargando...</span>

--- a/public/app2.html
+++ b/public/app2.html
@@ -333,7 +333,7 @@
     <!-- End of Page Wrapper -->
 
     <!-- Contenedor para notificaciones Toast -->
-    <div id="toast-container"></div>
+    <div id="toast-container" role="region" aria-live="polite"></div>
 
     <!-- Scroll to Top Button-->
     <a class="scroll-to-top rounded" href="#page-top">

--- a/public/js/app1-logic.js
+++ b/public/js/app1-logic.js
@@ -114,6 +114,8 @@ function showToast(message, type = 'success') {
     };
     const toast = document.createElement('div');
     toast.className = `toast flex items-center w-full max-w-xs p-4 text-gray-500 bg-white rounded-lg shadow-lg`;
+    toast.setAttribute('role', 'alert');
+    toast.setAttribute('aria-atomic', 'true');
     toast.innerHTML = `
         <div class="inline-flex items-center justify-center flex-shrink-0 w-8 h-8 ${iconMap[type].color} bg-gray-100 rounded-lg">
             <i data-lucide="${iconMap[type].name}" class="w-5 h-5"></i>

--- a/public/js/app2-logic.js
+++ b/public/js/app2-logic.js
@@ -57,6 +57,8 @@ document.addEventListener('DOMContentLoaded', () => {
         };
         const toast = document.createElement('div');
         toast.className = `toast flex items-center w-full max-w-xs p-4 text-gray-500 bg-white rounded-lg shadow-lg`;
+        toast.setAttribute('role', 'alert');
+        toast.setAttribute('aria-atomic', 'true');
         toast.innerHTML = `
             <div class="inline-flex items-center justify-center flex-shrink-0 w-8 h-8 ${iconMap[type].color} bg-gray-100 rounded-lg">
                 <i data-lucide="${iconMap[type].name}" class="w-5 h-5"></i>


### PR DESCRIPTION
## Summary
- add `role="region"` and `aria-live="polite"` to toast container in app pages
- mark dynamically created toasts as atomic alerts

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*
- `npm install -g pa11y` *(fails: Failed to set up chrome v138.0.7204.92)*

------
https://chatgpt.com/codex/tasks/task_e_686dd5123ce0832fa330a27a73d9e1e2