### PR TITLE
Add subtle toast animations

### DIFF
--- a/public/app1.html
+++ b/public/app1.html
@@ -77,11 +77,19 @@
             from { transform: translateX(0); opacity: 1; }
             to { transform: translateX(120%); opacity: 0; }
         }
+        @keyframes toast-pop-in {
+            from { transform: translateX(100%) scale(0.95); opacity: 0; }
+            to { transform: translateX(0) scale(1); opacity: 1; }
+        }
+        @keyframes toast-pop-out {
+            from { transform: translateX(0) scale(1); opacity: 1; }
+            to { transform: translateX(120%) scale(0.95); opacity: 0; }
+        }
         .toast {
-            animation: toast-in 0.5s cubic-bezier(0.21, 1.02, 0.73, 1) forwards;
+            animation: toast-pop-in 0.5s cubic-bezier(0.21, 1.02, 0.73, 1) forwards;
         }
         .toast.closing {
-            animation: toast-out 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+            animation: toast-pop-out 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
         }
         
         /* Ajustes para la integración */

--- a/public/app2.html
+++ b/public/app2.html
@@ -100,11 +100,19 @@
             from { transform: translateX(0); opacity: 1; }
             to { transform: translateX(120%); opacity: 0; }
         }
+        @keyframes toast-pop-in {
+            from { transform: translateX(100%) scale(0.95); opacity: 0; }
+            to { transform: translateX(0) scale(1); opacity: 1; }
+        }
+        @keyframes toast-pop-out {
+            from { transform: translateX(0) scale(1); opacity: 1; }
+            to { transform: translateX(120%) scale(0.95); opacity: 0; }
+        }
         .toast {
-            animation: toast-in 0.5s cubic-bezier(0.21, 1.02, 0.73, 1) forwards;
+            animation: toast-pop-in 0.5s cubic-bezier(0.21, 1.02, 0.73, 1) forwards;
         }
         .toast.closing {
-            animation: toast-out 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+            animation: toast-pop-out 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
         }
     </style>
 </head>

--- a/public/js/app1-logic.js
+++ b/public/js/app1-logic.js
@@ -108,12 +108,12 @@ function refreshIcons() {
 
 function showToast(message, type = 'success') {
     const iconMap = {
-        success: { name: 'check-circle', color: 'text-green-500' },
-        error: { name: 'x-circle', color: 'text-red-500' },
-        info: { name: 'info', color: 'text-blue-500' }
+        success: { name: 'check-circle', color: 'text-green-500', border: 'border-green-500' },
+        error: { name: 'x-circle', color: 'text-red-500', border: 'border-red-500' },
+        info: { name: 'info', color: 'text-blue-500', border: 'border-blue-500' }
     };
     const toast = document.createElement('div');
-    toast.className = `toast flex items-center w-full max-w-xs p-4 text-gray-500 bg-white rounded-lg shadow-lg`;
+    toast.className = `toast flex items-center w-full max-w-xs p-4 text-gray-700 bg-white rounded-lg shadow-lg border-l-4 ${iconMap[type].border}`;
     toast.setAttribute('role', 'alert');
     toast.setAttribute('aria-atomic', 'true');
     toast.innerHTML = `

--- a/public/js/app2-logic.js
+++ b/public/js/app2-logic.js
@@ -51,12 +51,12 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Sistema de Notificaciones Toast ---
     function showToast(message, type = 'success') {
         const iconMap = {
-            success: { name: 'check-circle', color: 'text-green-500' },
-            error: { name: 'x-circle', color: 'text-red-500' },
-            info: { name: 'info', color: 'text-blue-500' }
+            success: { name: 'check-circle', color: 'text-green-500', border: 'border-green-500' },
+            error: { name: 'x-circle', color: 'text-red-500', border: 'border-red-500' },
+            info: { name: 'info', color: 'text-blue-500', border: 'border-blue-500' }
         };
         const toast = document.createElement('div');
-        toast.className = `toast flex items-center w-full max-w-xs p-4 text-gray-500 bg-white rounded-lg shadow-lg`;
+        toast.className = `toast flex items-center w-full max-w-xs p-4 text-gray-700 bg-white rounded-lg shadow-lg border-l-4 ${iconMap[type].border}`;
         toast.setAttribute('role', 'alert');
         toast.setAttribute('aria-atomic', 'true');
         toast.innerHTML = `


### PR DESCRIPTION
## Summary
- animate toast notifications with scale keyframes
- color toast borders depending on type

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686e779f059c832f8e30d79fe24b7273